### PR TITLE
New parameter to kill traceroute syscall after n tentatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -v -m 20000 -p"
+    "test": "lab -v -m 60000 -p"
   },
   "keywords": [
     "traceroute",

--- a/test/index.js
+++ b/test/index.js
@@ -36,4 +36,17 @@ describe('Traceroute', () => {
             done();
         });
     });
+
+    it('traces a fake route and quits after 5 hops in a row', (done) => {
+
+        Traceroute.trace('127.0.0.127', (err, hops) => {
+
+            expect(err).to.not.exist();
+            expect(hops).to.exist();
+            for (let hop of hops) {
+                expect(hop).to.equal(false);
+            }
+            done();
+        });
+    });
 });

--- a/traceroute.js
+++ b/traceroute.js
@@ -25,8 +25,6 @@ internals.Traceroute.trace = function (host, maxNullHops, callback) {
         maxNullHops = defaultMaxNullHops;
     } else if (maxNullHops === undefined) {
         maxNullHops = defaultMaxNullHops;
-    } else if (!Number.isInteger(maxNullHops)) {
-        throw new Error('second parameter must be a callback or an integer');
     }
 
     const Emitter = function () {
@@ -72,7 +70,7 @@ internals.Traceroute.trace = function (host, maxNullHops, callback) {
                 nullHops = 0;
             }
             // send a sigint to kill the traceroute process when it reach $maxNullHops hops in a row
-            if (nullHops >= maxNullHops) {
+            if (maxNullHops && nullHops >= maxNullHops) {
                 traceroute.kill('SIGINT');
             }
         });


### PR DESCRIPTION
Hi!
I added a new parameter that permits to kill traceroute syscall after n null hops in a row.
With this fix, no traceroute syscall will last forever in processes queue.
